### PR TITLE
fix: 2027 audit follow-ups (redirect, 2024 award count, sponsors labels)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,7 @@ eu-hot-sauce-awards/scripts/import-historical-data-README.md
 
 # Claude
 .claude/
+.mcp.json
+
+# Local dev/scratch files (exports, one-off scripts, working data)
+/dev-files/

--- a/eu-hot-sauce-awards/next.config.mjs
+++ b/eu-hot-sauce-awards/next.config.mjs
@@ -26,6 +26,13 @@ const nextConfig = {
         destination: 'https://heatawards.eu/:path*',
         permanent: true,
       },
+      {
+        // Leftover permalink shape from the old WordPress site — send any
+        // stray bookmarks/backlinks to the real archive route.
+        source: '/results-2024',
+        destination: '/results/2024',
+        permanent: true,
+      },
     ];
   },
 };

--- a/eu-hot-sauce-awards/src/app/results/[year]/page.tsx
+++ b/eu-hot-sauce-awards/src/app/results/[year]/page.tsx
@@ -27,6 +27,11 @@ async function getResultsByYear(year: number) {
     .from("past_results")
     .select("code, entry_name, company_name, country, category, area, award, position, score")
     .eq("year", year)
+    // The 2024 legacy import carried every entrant, not just medalists (unlike
+    // 2025/2026, which only ever had award rows inserted) — filter to award
+    // rows here so "award-winning entries" is accurate for every year.
+    .not("award", "is", null)
+    .neq("award", "")
     .order("category", { ascending: true })
     .order("position", { ascending: true, nullsFirst: false });
   if (error) {

--- a/eu-hot-sauce-awards/src/app/sponsors/page.tsx
+++ b/eu-hot-sauce-awards/src/app/sponsors/page.tsx
@@ -85,7 +85,7 @@ export default async function SponsorsPage() {
                 {countries}
               </strong>
               <span className="text-[11px] uppercase tracking-[0.12em] text-gray-300">
-                Countries ({PREVIOUS_COMPETITION_YEAR})
+                European countries ({PREVIOUS_COMPETITION_YEAR})
               </span>
             </div>
             <div>
@@ -93,7 +93,7 @@ export default async function SponsorsPage() {
                 {makers}
               </strong>
               <span className="text-[11px] uppercase tracking-[0.12em] text-gray-300">
-                Award-winning makers ({PREVIOUS_COMPETITION_YEAR})
+                European award-winning makers ({PREVIOUS_COMPETITION_YEAR})
               </span>
             </div>
             <div>

--- a/supabase/migrations/20260818000000_past_results_year_counts_award_only.sql
+++ b/supabase/migrations/20260818000000_past_results_year_counts_award_only.sql
@@ -1,0 +1,18 @@
+-- The 2024 legacy import carried every entrant (not just medalists), unlike
+-- 2025/2026 which only ever had award rows inserted. This function feeds the
+-- "X award-winning entries" count shown on the results archive index, so it
+-- needs to filter to award rows the same way src/app/results/[year]/page.tsx
+-- now does — otherwise 2024 shows 193 (all entrants) instead of the true 50
+-- award-winning entries.
+CREATE OR REPLACE FUNCTION get_past_results_year_counts()
+RETURNS TABLE(year integer, count bigint)
+LANGUAGE sql
+STABLE
+SET search_path = public
+AS $$
+  SELECT year, count(*) AS count
+  FROM past_results
+  WHERE award IS NOT NULL AND award <> ''
+  GROUP BY year
+  ORDER BY year DESC;
+$$;


### PR DESCRIPTION
## Summary
- Redirect legacy `/results-2024` URL (old WordPress permalink) to `/results/2024`
- Fix 2024 results showing 193 "award-winning entries" when only 50 rows actually have an award — the legacy import carried every entrant, not just medalists. Filtered both the per-year query and the results-index `get_past_results_year_counts` RPC (migration included, already applied to prod DB).
- Label sponsors page stats "European countries/makers" instead of unqualified "Countries" — that page is scoped to `area = EURO`, which reads ambiguously next to `/results/2026`'s global totals.

Also includes an earlier `.gitignore` commit (dev-files/.mcp.json cleanup) that was pending on main.

## Test plan
- [x] `npm run build` — compiles clean, all 38 routes generate
- [x] Verified on local dev server: `/results/2024` shows 50 award-winning entries (was 193), results index shows 50 for the 2024 card
- [x] Verified sponsors page renders "European countries (2026)" / "European award-winning makers (2026)"
- [x] Migration applied directly to production Supabase project and re-queried to confirm `get_past_results_year_counts()` now returns 50 for 2024

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PfdWwGgLTJ8BUbBiotqDsu