### PR TITLE
feat: cookie consent banner + publish updated cookie policy

### DIFF
--- a/eu-hot-sauce-awards/src/app/cookies/page.tsx
+++ b/eu-hot-sauce-awards/src/app/cookies/page.tsx
@@ -3,6 +3,7 @@ import type { Metadata } from 'next';
 import HeatHeader from '@/components/HeatHeader';
 import HeatFooter from '@/components/HeatFooter';
 import Breadcrumbs from '@/components/Breadcrumbs';
+import CookiePreferencesButton from '@/components/CookiePreferencesButton';
 
 export const metadata: Metadata = {
   title: 'Cookie Policy',
@@ -29,190 +30,118 @@ const CookiesPage = () => {
             <div className="space-y-8">
               <div>
                 <p className="text-black/75 leading-relaxed mb-4">
-                  This Cookie Policy was last updated on October 27, 2022 and applies to citizens and legal permanent residents of the European Economic Area and Switzerland.
+                  This Cookie Policy was last updated on August 18, 2026 and applies to visitors to heatawards.eu, including citizens and residents of the European Economic Area, the UK, and Switzerland.
                 </p>
               </div>
 
               <div>
-                <h2 className="font-[family-name:var(--font-archivo-black)] text-xl uppercase tracking-[0.03em] border-b-2 border-black pb-2 mb-3">1. Introduction</h2>
+                <h2 className="font-[family-name:var(--font-archivo-black)] text-xl uppercase tracking-[0.03em] border-b-2 border-black pb-2 mb-3">1. Who we are</h2>
                 <p className="text-black/75 leading-relaxed">
-                  Our website, <a href="https://heatawards.eu" className="text-black underline font-semibold hover:opacity-70">https://heatawards.eu</a> (hereinafter: "the website") uses cookies and other related technologies (for convenience all technologies are referred to as "cookies"). Cookies are also placed by third parties we have engaged. In the document below we inform you about the use of cookies on our website.
+                  This website, <a href="https://heatawards.eu" className="text-black underline font-semibold hover:opacity-70">heatawards.eu</a> (the &ldquo;Site&rdquo;), is operated by:
                 </p>
+                <div className="text-black/75 leading-relaxed mt-3">
+                  <p>Chili Punk Berlin</p>
+                  <p>Urbanstraße 96</p>
+                  <p>10967 Berlin, Germany</p>
+                  <p>VAT: DE314890098</p>
+                  <p>Email: <a href="mailto:heataward@gmail.com" className="text-black underline font-semibold hover:opacity-70">heataward@gmail.com</a></p>
+                </div>
               </div>
 
               <div>
                 <h2 className="font-[family-name:var(--font-archivo-black)] text-xl uppercase tracking-[0.03em] border-b-2 border-black pb-2 mb-3">2. What are cookies?</h2>
                 <p className="text-black/75 leading-relaxed">
-                  A cookie is a small simple file that is sent along with pages of this website and stored by your browser on the hard drive of your computer or another device. The information stored therein may be returned to our servers or to the servers of the relevant third parties during a subsequent visit.
-                </p>
-              </div>
-
-              <div>
-                <h2 className="font-[family-name:var(--font-archivo-black)] text-xl uppercase tracking-[0.03em] border-b-2 border-black pb-2 mb-3">3. What are scripts?</h2>
-                <p className="text-black/75 leading-relaxed">
-                  A script is a piece of program code that is used to make our website function properly and interactively. This code is executed on our server or on your device.
-                </p>
-              </div>
-
-              <div>
-                <h2 className="font-[family-name:var(--font-archivo-black)] text-xl uppercase tracking-[0.03em] border-b-2 border-black pb-2 mb-3">4. What is a web beacon?</h2>
-                <p className="text-black/75 leading-relaxed">
-                  A web beacon (or a pixel tag) is a small, invisible piece of text or image on a website that is used to monitor traffic on a website. In order to do this, various data about you is stored using web beacons.
-                </p>
-              </div>
-
-              <div>
-                <h2 className="font-[family-name:var(--font-archivo-black)] text-xl uppercase tracking-[0.03em] border-b-2 border-black pb-2 mb-3">5. Cookies</h2>
-
-                <h3 className="text-base font-bold text-black mb-2 mt-4">5.1 Technical or functional cookies</h3>
-                <p className="text-black/75 leading-relaxed">
-                  Some cookies ensure that certain parts of the website work properly and that your user preferences remain known. By placing functional cookies, we make it easier for you to visit our website. This way, you do not need to repeatedly enter the same information when visiting our website and, for example, the items remain in your shopping cart until you have paid. We may place these cookies without your consent.
-                </p>
-
-                <h3 className="text-base font-bold text-black mb-2 mt-4">5.2 Statistics cookies</h3>
-                <p className="text-black/75 leading-relaxed">
-                  We use statistics cookies to optimize the website experience for our users. With these statistics cookies we get insights in the usage of our website. We ask your permission to place statistics cookies.
-                </p>
-
-                <h3 className="text-base font-bold text-black mb-2 mt-4">5.3 Marketing/Tracking cookies</h3>
-                <p className="text-black/75 leading-relaxed">
-                  Marketing/Tracking cookies are cookies or any other form of local storage, used to create user profiles to display advertising or to track the user on this website or across several websites for similar marketing purposes.
-                </p>
-
-                <h3 className="text-base font-bold text-black mb-2 mt-4">5.4 Social media</h3>
-                <p className="text-black/75 leading-relaxed">
-                  On our website, we have included content from Facebook and Instagram to promote web pages (e.g. "like", "pin") or share (e.g. "tweet") on social networks like Facebook and Instagram. This content is embedded with code derived from Facebook and Instagram and places cookies. This content might store and process certain information for personalized advertising.
+                  A cookie is a small file placed on your device by your browser when you visit a website. Cookies let a site recognize your device on return visits, remember choices you&rsquo;ve made, and — depending on the type — help site owners understand how the site is used.
                 </p>
                 <p className="text-black/75 leading-relaxed mt-3">
-                  Please read the privacy statement of these social networks (which can change regularly) to read what they do with your (personal) data which they process using these cookies. The data that is retrieved is anonymized as much as possible. Facebook and Instagram are located in the United States.
+                  We also use similar technologies such as local storage; this policy refers to all of these collectively as &ldquo;cookies.&rdquo;
                 </p>
               </div>
 
               <div>
-                <h2 className="font-[family-name:var(--font-archivo-black)] text-xl uppercase tracking-[0.03em] border-b-2 border-black pb-2 mb-3">6. Placed cookies</h2>
+                <h2 className="font-[family-name:var(--font-archivo-black)] text-xl uppercase tracking-[0.03em] border-b-2 border-black pb-2 mb-3">3. Categories of cookies we use</h2>
 
-                <div className="space-y-4">
-                  <div>
-                    <h3 className="text-base font-bold text-black mb-2">WooCommerce</h3>
-                    <p className="text-black/75">Functional</p>
-                  </div>
-
-                  <div>
-                    <h3 className="text-base font-bold text-black mb-2">PHP</h3>
-                    <p className="text-black/75">Functional</p>
-                  </div>
-
-                  <div>
-                    <h3 className="text-base font-bold text-black mb-2">PayPal</h3>
-                    <p className="text-black/75">Functional</p>
-                  </div>
-
-                  <div>
-                    <h3 className="text-base font-bold text-black mb-2">Jetpack</h3>
-                    <p className="text-black/75">Statistics</p>
-                  </div>
-
-                  <div>
-                    <h3 className="text-base font-bold text-black mb-2">WordPress</h3>
-                    <p className="text-black/75">Functional</p>
-                  </div>
-
-                  <div>
-                    <h3 className="text-base font-bold text-black mb-2">Stripe</h3>
-                    <p className="text-black/75">Functional</p>
-                  </div>
-
-                  <div>
-                    <h3 className="text-base font-bold text-black mb-2">MailChimp</h3>
-                    <p className="text-black/75">Marketing, Statistics</p>
-                  </div>
-
-                  <div>
-                    <h3 className="text-base font-bold text-black mb-2">Automattic</h3>
-                    <p className="text-black/75">Statistics</p>
-                  </div>
-
-                  <div>
-                    <h3 className="text-base font-bold text-black mb-2">Facebook</h3>
-                    <p className="text-black/75">Marketing, Functional</p>
-                  </div>
-
-                  <div>
-                    <h3 className="text-base font-bold text-black mb-2">Complianz</h3>
-                    <p className="text-black/75">Functional</p>
-                  </div>
-
-                  <div>
-                    <h3 className="text-base font-bold text-black mb-2">Wistia</h3>
-                    <p className="text-black/75">Statistics</p>
-                  </div>
-
-                  <div>
-                    <h3 className="text-base font-bold text-black mb-2">Miscellaneous</h3>
-                    <p className="text-black/75">Purpose pending investigation</p>
-                  </div>
-                </div>
-              </div>
-
-              <div>
-                <h2 className="font-[family-name:var(--font-archivo-black)] text-xl uppercase tracking-[0.03em] border-b-2 border-black pb-2 mb-3">7. Consent</h2>
-                <p className="text-black/75 leading-relaxed mb-4">
-                  When you visit our website for the first time, we will show you a pop-up with an explanation about cookies. As soon as you click on "Save preferences", you consent to us using the categories of cookies and plug-ins you selected in the pop-up, as described in this Cookie Policy. You can disable the use of cookies via your browser, but please note that our website may no longer work properly.
-                </p>
-
-                <h3 className="text-base font-bold text-black mb-2 mt-4">7.1 Manage your consent settings</h3>
-                <div className="space-y-2 text-black/75">
-                  <p><strong className="text-black">Functional:</strong> Always active</p>
-                  <p><strong className="text-black">Statistics:</strong> Statistics</p>
-                  <p><strong className="text-black">Marketing:</strong> Marketing</p>
-                </div>
-              </div>
-
-              <div>
-                <h2 className="font-[family-name:var(--font-archivo-black)] text-xl uppercase tracking-[0.03em] border-b-2 border-black pb-2 mb-3">8. Enabling/disabling and deleting cookies</h2>
-                <p className="text-black/75 leading-relaxed mb-3">
-                  You can use your internet browser to automatically or manually delete cookies. You can also specify that certain cookies may not be placed. Another option is to change the settings of your internet browser so that you receive a message each time a cookie is placed. For more information about these options, please refer to the instructions in the Help section of your browser.
-                </p>
+                <h3 className="text-base font-bold text-black mb-2 mt-4">3.1 Strictly necessary / functional cookies</h3>
                 <p className="text-black/75 leading-relaxed">
-                  Please note that our website may not work properly if all cookies are disabled. If you do delete the cookies in your browser, they will be placed again after your consent when you visit our website again.
+                  These are required for core site functionality and can&rsquo;t be switched off:
                 </p>
-              </div>
-
-              <div>
-                <h2 className="font-[family-name:var(--font-archivo-black)] text-xl uppercase tracking-[0.03em] border-b-2 border-black pb-2 mb-3">9. Your rights with respect to personal data</h2>
-                <p className="text-black/75 leading-relaxed mb-3">
-                  You have the following rights with respect to your personal data:
-                </p>
-                <ul className="list-disc list-inside text-black/75 leading-relaxed space-y-2">
-                  <li>You have the right to know why your personal data is needed, what will happen to it, and how long it will be retained for.</li>
-                  <li>Right of access: You have the right to access your personal data that is known to us.</li>
-                  <li>Right to rectification: you have the right to supplement, correct, have deleted or blocked your personal data whenever you wish.</li>
-                  <li>If you give us your consent to process your data, you have the right to revoke that consent and to have your personal data deleted.</li>
-                  <li>Right to transfer your data: you have the right to request all your personal data from the controller and transfer it in its entirety to another controller.</li>
-                  <li>Right to object: you may object to the processing of your data. We comply with this, unless there are justified grounds for processing.</li>
+                <ul className="list-disc list-inside text-black/75 leading-relaxed mt-2 space-y-1">
+                  <li>Session/authentication cookies for the magic-link login system, used by entrants, judges, and admins to stay logged in.</li>
+                  <li>Local storage used during judging to hold scores before bulk submission, so a dropped connection doesn&rsquo;t lose a judge&rsquo;s work.</li>
+                  <li>A cookie preference cookie, once you make a choice in the banner below, so we don&rsquo;t ask again on every visit.</li>
                 </ul>
-                <p className="text-black/75 leading-relaxed mt-3">
-                  To exercise these rights, please contact us. Please refer to the contact details at the bottom of this Cookie Policy. If you have a complaint about how we handle your data, we would like to hear from you, but you also have the right to submit a complaint to the supervisory authority (the Data Protection Authority).
+
+                <h3 className="text-base font-bold text-black mb-2 mt-4">3.2 Analytics / statistics cookies</h3>
+                <p className="text-black/75 leading-relaxed">
+                  With your consent, we use Google Analytics (GA4) to understand how visitors use the Site — pages viewed, general location (country-level), and interactions like sponsor link clicks. Google may process this data on servers outside the EEA. You can learn more at{' '}
+                  <a href="https://policies.google.com/privacy" target="_blank" rel="noopener noreferrer" className="text-black underline font-semibold hover:opacity-70">Google&rsquo;s Privacy Policy</a>{' '}
+                  or opt out using the{' '}
+                  <a href="https://tools.google.com/dlpage/gaoptout" target="_blank" rel="noopener noreferrer" className="text-black underline font-semibold hover:opacity-70">Google Analytics Opt-out Browser Add-on</a>.
+                  These cookies are only set if you accept them in the cookie banner — see Section 5.
+                </p>
+
+                <h3 className="text-base font-bold text-black mb-2 mt-4">3.3 Payment processing</h3>
+                <p className="text-black/75 leading-relaxed">
+                  If you submit a competition entry or pay a sponsorship/judge participation fee through the Site, our payment processor Stripe sets cookies to process your payment securely and prevent fraud. Their privacy policy: <a href="https://stripe.com/privacy" target="_blank" rel="noopener noreferrer" className="text-black underline font-semibold hover:opacity-70">stripe.com/privacy</a>.
+                </p>
+
+                <h3 className="text-base font-bold text-black mb-2 mt-4">3.4 Social media</h3>
+                <p className="text-black/75 leading-relaxed">
+                  The Site links out to our Instagram profile. Clicking that link takes you to instagram.com, which may set its own cookies under Meta&rsquo;s policies — we don&rsquo;t control that, and no Instagram content is embedded directly on this Site.
+                </p>
+
+                <h3 className="text-base font-bold text-black mb-2 mt-4">3.5 Email / newsletter</h3>
+                <p className="text-black/75 leading-relaxed">
+                  Newsletter sign-ups and transactional emails (entry confirmations, judging updates) are sent directly by us and do not include third-party tracking pixels.
                 </p>
               </div>
 
               <div>
-                <h2 className="font-[family-name:var(--font-archivo-black)] text-xl uppercase tracking-[0.03em] border-b-2 border-black pb-2 mb-3">10. Contact details</h2>
+                <h2 className="font-[family-name:var(--font-archivo-black)] text-xl uppercase tracking-[0.03em] border-b-2 border-black pb-2 mb-3">4. Cookies we do NOT use</h2>
+                <p className="text-black/75 leading-relaxed">
+                  We do not use third-party advertising or retargeting cookies. We do not use PayPal, Mailchimp, WordPress/WooCommerce, Jetpack, or Wistia.
+                </p>
+              </div>
+
+              <div>
+                <h2 className="font-[family-name:var(--font-archivo-black)] text-xl uppercase tracking-[0.03em] border-b-2 border-black pb-2 mb-3">5. Managing your cookie preferences</h2>
+                <p className="text-black/75 leading-relaxed mb-4">
+                  When you first visit the Site, you&rsquo;ll be shown a cookie banner where you can accept or decline analytics cookies. You can change your choice at any time using the{' '}
+                  <CookiePreferencesButton className="text-black underline font-semibold hover:opacity-70" />{' '}
+                  link in the footer of any page.
+                </p>
+                <p className="text-black/75 leading-relaxed">
+                  You can also control or delete cookies through your browser settings. Note that blocking essential cookies may prevent parts of the Site — such as logging in to submit an entry or judge application — from working correctly.
+                </p>
+              </div>
+
+              <div>
+                <h2 className="font-[family-name:var(--font-archivo-black)] text-xl uppercase tracking-[0.03em] border-b-2 border-black pb-2 mb-3">6. Your rights</h2>
                 <p className="text-black/75 leading-relaxed mb-3">
-                  For questions and/or comments about our Cookie Policy and this statement, please contact us by using the following contact details:
+                  If you are located in the EEA, UK, or Switzerland, you have rights under GDPR (or equivalent) regarding your personal data, including the right to access, correct, or delete data we hold about you, and the right to withdraw consent for non-essential cookies at any time without affecting the lawfulness of processing before withdrawal.
                 </p>
-                <div className="text-black/75 leading-relaxed mb-4">
+                <p className="text-black/75 leading-relaxed mb-3">
+                  To exercise these rights, or if you have questions about this policy, contact us at <a href="mailto:heataward@gmail.com" className="text-black underline font-semibold hover:opacity-70">heataward@gmail.com</a>.
+                </p>
+                <p className="text-black/75 leading-relaxed">
+                  If you believe we are processing your data unlawfully, you also have the right to lodge a complaint with your local data protection authority. For Germany, this is the Berliner Beauftragte für Datenschutz und Informationsfreiheit (or the relevant authority for your state), or the EU&rsquo;s directory of supervisory authorities: <a href="https://ec.europa.eu/justice/data-protection/bodies/authorities/index_en.htm" target="_blank" rel="noopener noreferrer" className="text-black underline font-semibold hover:opacity-70">ec.europa.eu</a>.
+                </p>
+              </div>
+
+              <div>
+                <h2 className="font-[family-name:var(--font-archivo-black)] text-xl uppercase tracking-[0.03em] border-b-2 border-black pb-2 mb-3">7. Changes to this policy</h2>
+                <p className="text-black/75 leading-relaxed">
+                  We may update this Cookie Policy from time to time, for example if we change the tools or third-party services the Site uses. The &ldquo;last updated&rdquo; date at the top will reflect the most recent revision. We encourage you to check back periodically.
+                </p>
+              </div>
+
+              <div>
+                <h2 className="font-[family-name:var(--font-archivo-black)] text-xl uppercase tracking-[0.03em] border-b-2 border-black pb-2 mb-3">8. Contact us</h2>
+                <div className="text-black/75 leading-relaxed">
                   <p>Chili Punk Berlin</p>
-                  <p>Ossastr 21A</p>
-                  <p>12045 Berlin</p>
-                  <p>Germany</p>
-                  <p>Website: <a href="https://heatawards.eu" className="text-black underline font-semibold hover:opacity-70">https://heatawards.eu</a></p>
-                  <p>Email: <a href="mailto:chilipunkberlin@gmail.com" className="text-black underline font-semibold hover:opacity-70">chilipunkberlin@gmail.com</a></p>
-                  <p>Phone number: 017621391410</p>
+                  <p>Urbanstraße 96, 10967 Berlin, Germany</p>
+                  <p>Email: <a href="mailto:heataward@gmail.com" className="text-black underline font-semibold hover:opacity-70">heataward@gmail.com</a></p>
                 </div>
-                <p className="text-black/75 leading-relaxed italic">
-                  This Cookie Policy was synchronized with cookiedatabase.org on January 16, 2025.
-                </p>
               </div>
             </div>
           </div>

--- a/eu-hot-sauce-awards/src/app/layout.tsx
+++ b/eu-hot-sauce-awards/src/app/layout.tsx
@@ -3,7 +3,7 @@ import { Inter, Archivo_Black } from "next/font/google";
 import "./globals.css";
 import GlobalNav from "@/components/GlobalNav";
 import Footer from "@/components/Footer";
-import Script from "next/script";
+import CookieConsentBanner from "@/components/CookieConsentBanner";
 
 const inter = Inter({
   subsets: ["latin"],
@@ -53,30 +53,11 @@ export default function RootLayout({
 
   return (
     <html lang="en">
-      <head>
-        {GA_MEASUREMENT_ID && (
-          <>
-            <Script
-              src={`https://www.googletagmanager.com/gtag/js?id=${GA_MEASUREMENT_ID}`}
-              strategy="afterInteractive"
-            />
-            <Script id="google-analytics" strategy="afterInteractive">
-              {`
-                window.dataLayer = window.dataLayer || [];
-                function gtag(){dataLayer.push(arguments);}
-                gtag('js', new Date());
-                gtag('config', '${GA_MEASUREMENT_ID}', {
-                  page_path: window.location.pathname,
-                });
-              `}
-            </Script>
-          </>
-        )}
-      </head>
       <body className={`${inter.variable} ${archivoBlack.variable} antialiased bg-[#08040e] text-white`}>
         <GlobalNav />
         <main>{children}</main>
         <Footer />
+        <CookieConsentBanner gaId={GA_MEASUREMENT_ID} />
       </body>
     </html>
   );

--- a/eu-hot-sauce-awards/src/components/CookieConsentBanner.tsx
+++ b/eu-hot-sauce-awards/src/components/CookieConsentBanner.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import Script from "next/script";
+import {
+  COOKIE_CONSENT_REOPEN_EVENT,
+  type ConsentStatus,
+  getStoredConsent,
+  setStoredConsent,
+} from "@/lib/cookieConsent";
+
+// Only non-essential cookie category on the Site is analytics (GA4) — no
+// other third-party embeds, ad tech, or preference cookies exist, so a
+// single accept/decline choice covers it rather than a category picker.
+export default function CookieConsentBanner({ gaId }: { gaId?: string }) {
+  const [status, setStatus] = useState<ConsentStatus | null>(null);
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    const stored = getStoredConsent();
+    setStatus(stored);
+    if (stored === null) setVisible(true);
+
+    const reopen = () => setVisible(true);
+    window.addEventListener(COOKIE_CONSENT_REOPEN_EVENT, reopen);
+    return () => window.removeEventListener(COOKIE_CONSENT_REOPEN_EVENT, reopen);
+  }, []);
+
+  const decide = (next: ConsentStatus) => {
+    setStoredConsent(next);
+    setStatus(next);
+    setVisible(false);
+  };
+
+  return (
+    <>
+      {gaId && status === "accepted" && (
+        <>
+          <Script src={`https://www.googletagmanager.com/gtag/js?id=${gaId}`} strategy="afterInteractive" />
+          <Script id="google-analytics" strategy="afterInteractive">
+            {`
+              window.dataLayer = window.dataLayer || [];
+              function gtag(){dataLayer.push(arguments);}
+              gtag('js', new Date());
+              gtag('config', '${gaId}', {
+                page_path: window.location.pathname,
+              });
+            `}
+          </Script>
+        </>
+      )}
+
+      {visible && (
+        <div className="fixed inset-x-0 bottom-0 z-50 border-t-[3px] border-[#F5C518] bg-black px-6 py-5 text-white">
+          <div className="mx-auto flex max-w-[1240px] flex-col items-start gap-4 md:flex-row md:items-center md:justify-between">
+            <p className="text-sm leading-relaxed text-gray-300">
+              We use cookies for essential site functions (staying logged in) and, with your consent, analytics
+              to understand how the Site is used. See our{" "}
+              <Link href="/cookies" className="underline hover:text-[#F5C518]">
+                Cookie Policy
+              </Link>{" "}
+              for details.
+            </p>
+            <div className="flex flex-shrink-0 gap-3">
+              <button
+                type="button"
+                onClick={() => decide("declined")}
+                className="border-2 border-white px-5 py-2.5 text-xs font-semibold uppercase tracking-[0.08em] text-white hover:bg-white hover:text-black"
+              >
+                Decline
+              </button>
+              <button
+                type="button"
+                onClick={() => decide("accepted")}
+                className="bg-[#F5C518] px-5 py-2.5 font-[family-name:var(--font-archivo-black)] text-xs uppercase tracking-[0.08em] text-black hover:bg-[#e0a800]"
+              >
+                Accept
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/eu-hot-sauce-awards/src/components/CookiePreferencesButton.tsx
+++ b/eu-hot-sauce-awards/src/components/CookiePreferencesButton.tsx
@@ -1,0 +1,11 @@
+"use client";
+
+import { openCookiePreferences } from "@/lib/cookieConsent";
+
+export default function CookiePreferencesButton({ className }: { className?: string }) {
+  return (
+    <button type="button" onClick={openCookiePreferences} className={className}>
+      Cookie preferences
+    </button>
+  );
+}

--- a/eu-hot-sauce-awards/src/components/Footer.tsx
+++ b/eu-hot-sauce-awards/src/components/Footer.tsx
@@ -4,6 +4,7 @@
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import { usesNewDesign } from '@/lib/newDesignRoutes';
+import CookiePreferencesButton from '@/components/CookiePreferencesButton';
 
 const FooterLink = ({ href, children }: { href: string, children: React.ReactNode }) => (
   <Link href={href} className="text-base text-gray-400 hover:text-white">
@@ -67,6 +68,7 @@ const Footer = () => {
             <FooterLink href="/terms">Terms</FooterLink>
             <FooterLink href="/privacy">Privacy Policy</FooterLink>
             <FooterLink href="/cookies">Cookie Policy</FooterLink>
+            <CookiePreferencesButton className="text-base text-gray-400 hover:text-white" />
           </div>
         </div>
       </div>

--- a/eu-hot-sauce-awards/src/components/HeatFooter.tsx
+++ b/eu-hot-sauce-awards/src/components/HeatFooter.tsx
@@ -1,6 +1,7 @@
 import Link from 'next/link';
 import Image from 'next/image';
 import { PREVIOUS_COMPETITION_YEAR } from '@/lib/config';
+import CookiePreferencesButton from '@/components/CookiePreferencesButton';
 
 const FooterCol = ({
   title,
@@ -84,6 +85,7 @@ export default function HeatFooter() {
             <Link href="/terms" className="hover:text-[#F5C518]">Terms</Link>
             <Link href="/privacy" className="hover:text-[#F5C518]">Privacy</Link>
             <Link href="/cookies" className="hover:text-[#F5C518]">Cookies</Link>
+            <CookiePreferencesButton className="hover:text-[#F5C518]" />
           </div>
         </div>
       </div>

--- a/eu-hot-sauce-awards/src/lib/cookieConsent.ts
+++ b/eu-hot-sauce-awards/src/lib/cookieConsent.ts
@@ -1,0 +1,23 @@
+export type ConsentStatus = "accepted" | "declined";
+
+const STORAGE_KEY = "ehsa_cookie_consent";
+
+// Fired by the footer's "Cookie preferences" link so the banner can be
+// reopened from anywhere without wiring a shared React context.
+export const COOKIE_CONSENT_REOPEN_EVENT = "ehsa:cookie-consent-reopen";
+
+export function getStoredConsent(): ConsentStatus | null {
+  if (typeof window === "undefined") return null;
+  const value = window.localStorage.getItem(STORAGE_KEY);
+  return value === "accepted" || value === "declined" ? value : null;
+}
+
+export function setStoredConsent(status: ConsentStatus) {
+  if (typeof window === "undefined") return;
+  window.localStorage.setItem(STORAGE_KEY, status);
+}
+
+export function openCookiePreferences() {
+  if (typeof window === "undefined") return;
+  window.dispatchEvent(new Event(COOKIE_CONSENT_REOPEN_EVENT));
+}


### PR DESCRIPTION
## Summary
- GA4 was loading unconditionally with no consent gate despite being live in production (`NEXT_PUBLIC_GA_MEASUREMENT_ID` set) — real GDPR compliance gap on an EU-facing site. Added a real accept/decline consent banner; GA scripts now only mount after acceptance.
- `CookiePreferencesButton` lets visitors change their choice any time, from either footer or inline in the cookie policy copy.
- Replaced the stale Oct 2022 `/cookies` page (old WooCommerce/Jetpack/PayPal/Wistia vendor list, wrong address, wrong contact email) with copy verified against the current codebase and production config — Stripe only, GA4 (now consent-gated), no third-party ESP, Instagram is a plain link not an embed.

## Test plan
- [x] `npm run lint` / `npm run build` — clean
- [x] Manually verified in-browser: fresh visit shows banner, GA scripts/`window.gtag` absent until Accept is clicked, Decline persists across reload with GA staying off, footer "Cookie preferences" link reopens the banner to change the choice
- [x] Found and fixed a race condition during testing (banner was reappearing on every load even after declining, due to two effects reading state before it settled) — fixed before this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PfdWwGgLTJ8BUbBiotqDsu